### PR TITLE
Add basename and fix extension value for fog file

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -13,6 +13,7 @@ module CarrierWave
   # It's probably needlessly comprehensive and complex. Help is appreciated.
   #
   class SanitizedFile
+    include CarrierWave::Utilities::FileName
 
     attr_reader :file
 
@@ -57,29 +58,6 @@ module CarrierWave
     end
 
     alias_method :identifier, :filename
-
-    ##
-    # Returns the part of the filename before the extension. So if a file is called 'test.jpeg'
-    # this would return 'test'
-    #
-    # === Returns
-    #
-    # [String] the first part of the filename
-    #
-    def basename
-      split_extension(filename)[0] if filename
-    end
-
-    ##
-    # Returns the file extension
-    #
-    # === Returns
-    #
-    # [String] the extension
-    #
-    def extension
-      split_extension(filename)[1] if filename
-    end
 
     ##
     # Returns the file's size.
@@ -349,21 +327,5 @@ module CarrierWave
 
       Marcel::Magic.by_path(path).to_s
     end
-
-    def split_extension(filename)
-      # regular expressions to try for identifying extensions
-      extension_matchers = [
-        /\A(.+)\.(tar\.([glx]?z|bz2))\z/, # matches "something.tar.gz"
-        /\A(.+)\.([^\.]+)\z/ # matches "something.jpg"
-      ]
-
-      extension_matchers.each do |regexp|
-        if filename =~ regexp
-          return $1, $2
-        end
-      end
-      return filename, "" # In case we weren't able to split the extension
-    end
-
   end # SanitizedFile
 end # CarrierWave

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -165,6 +165,7 @@ module CarrierWave
         DEFAULT_S3_REGION = 'us-east-1'
 
         include CarrierWave::Utilities::Uri
+        include CarrierWave::Utilities::FileName
 
         ##
         # Current local path to file
@@ -256,18 +257,6 @@ module CarrierWave
           directory.files.new(:key => path).destroy.tap do |result|
             @file = nil if result
           end
-        end
-
-        ##
-        # Return extension of file
-        #
-        # === Returns
-        #
-        # [String] extension of file or nil if the file has no extension
-        #
-        def extension
-          path_elements = path.split('.')
-          path_elements.last if path_elements.size > 1
         end
 
         ##

--- a/lib/carrierwave/utilities.rb
+++ b/lib/carrierwave/utilities.rb
@@ -1,4 +1,5 @@
 require 'carrierwave/utilities/uri'
+require 'carrierwave/utilities/file_name'
 
 module CarrierWave
   module Utilities

--- a/lib/carrierwave/utilities/file_name.rb
+++ b/lib/carrierwave/utilities/file_name.rb
@@ -1,0 +1,47 @@
+module CarrierWave
+  module Utilities
+    module FileName
+
+      ##
+      # Returns the part of the filename before the extension. So if a file is called 'test.jpeg'
+      # this would return 'test'
+      #
+      # === Returns
+      #
+      # [String] the first part of the filename
+      #
+      def basename
+        split_extension(filename)[0] if filename
+      end
+
+      ##
+      # Returns the file extension
+      #
+      # === Returns
+      #
+      # [String] extension of file or "" if the file has no extension
+      #
+      def extension
+        split_extension(filename)[1] if filename
+      end
+
+      private
+
+      def split_extension(filename)
+        # regular expressions to try for identifying extensions
+        extension_matchers = [
+          /\A(.+)\.(tar\.([glx]?z|bz2))\z/, # matches "something.tar.gz"
+          /\A(.+)\.([^\.]+)\z/ # matches "something.jpg"
+        ]
+
+        extension_matchers.each do |regexp|
+          if filename =~ regexp
+            return $1, $2
+          end
+        end
+
+        return filename, "" # In case we weren't able to split the extension
+      end
+    end # FileName
+  end # Utilities
+end # CarrierWave

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -89,7 +89,7 @@ end
           let(:store_path) { 'uploads/test' }
 
           it "should have no extension" do
-            expect(@fog_file.extension).to be_nil
+            expect(@fog_file.extension).to eq("")
           end
 
         end

--- a/spec/storage/fog_spec.rb
+++ b/spec/storage/fog_spec.rb
@@ -69,5 +69,67 @@ describe CarrierWave::Storage::Fog do
         end
       end
     end
+
+    describe "#basename" do
+      subject(:basename) { file.basename }
+
+      before { allow(file).to receive(:filename).and_return(filename) }
+
+      context "when file has complicated extensions" do
+        let(:filename) { "complex.filename.tar.gz" }
+
+        it "return correct basename" do
+          is_expected.to eq("complex.filename")
+        end
+      end
+
+      context "when file has simple extension" do
+        let(:filename) { "simple.extension" }
+
+        it "return correct basename" do
+          is_expected.to eq("simple")
+        end
+      end
+
+      context "when file has no extension" do
+        let(:filename) { "filename" }
+
+        it "return correct basename" do
+          is_expected.to eq("filename")
+        end
+      end
+    end
+
+    describe "#extension" do
+      subject(:extension) { file.extension }
+
+      before { allow(file).to receive(:filename).and_return(filename) }
+
+      %w[gz bz2 z lz xz].each do |ext|
+        context "when file has complicated extensions (tar.#{ext})" do
+          let(:filename) { "complex.filename.tar.#{ext}" }
+
+          it "return correct extension" do
+            is_expected.to eq("tar.#{ext}")
+          end
+        end
+      end
+
+      context "when file has simple extension" do
+        let(:filename) { "simple.extension" }
+
+        it "return correct extension" do
+          is_expected.to eq("extension")
+        end
+      end
+
+      context "when file has no extension" do
+        let(:filename) { "filename" }
+
+        it "return correct extension" do
+          is_expected.to eq("")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## About this PR

Make `basename` and `extension` of `CarrierWave::SanitizedFile` and `CarrierWave::Storage::Fog::File` the same

## My code
- **carrierwave.rb**

```
CarrierWave.configure do |config|
  case Rails.env
  when 'test', 'development'
    config.storage :file
    ...

  when 'production', 'staging'
    config.storage :fog
    ...
  end
end
```

- **models/document.rb**

```
class Document < ApplicationRecord
  mount_uploader :file, DocumentFileUploader
  ...
end
```

- What I want to show in view:
`document.file.file.extension`
`document.file.file.basename`

It works fine in `development` environment, but I have problem in `production`.
After checking, I got the result as below.
I think we shouldn't return different values in different environments for the same function.

## Actual results
### when file has complicated extensions , ex: `complex.filename.tar.gz`
- `config.storage :file`
<img width="440" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 48 09" src="https://user-images.githubusercontent.com/18423124/132948649-1b018318-1420-46e1-9b60-c9597203a094.png">

<img width="440" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 48 20" src="https://user-images.githubusercontent.com/18423124/132948664-b20abf7f-1c70-496d-a4b2-f537d0f024d4.png">

- `config.storage :fog`
<img width="444" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 42 32" src="https://user-images.githubusercontent.com/18423124/132948707-b768749a-e1c6-4b44-ab26-a45457fc1e74.png">

<img width="1008" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 45 49" src="https://user-images.githubusercontent.com/18423124/132950422-7b0d733d-20bd-4ff1-953e-db1c8200fda4.png">

### when file has simple extension, ex: `simple.extension`
<img width="440" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 49 06" src="https://user-images.githubusercontent.com/18423124/132948658-910dc12a-70d4-42b6-88a0-523e4d9b2f01.png">

<img width="440" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 49 14" src="https://user-images.githubusercontent.com/18423124/132948662-c5b90feb-d6bb-486a-9a50-2bae16863454.png">

- `config.storage :fog`
<img width="444" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 43 59" src="https://user-images.githubusercontent.com/18423124/132948712-ef3261d9-aa75-41ea-b9b8-4ad3001ed680.png">

### when file has no extension, ex: `filename`
- `config.storage :file`
<img width="440" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 49 33" src="https://user-images.githubusercontent.com/18423124/132948681-0d38a00b-b5e3-43ec-8b14-a7464a31792c.png">

<img width="440" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 50 02" src="https://user-images.githubusercontent.com/18423124/132948683-760571f3-bdf1-4b71-b0e3-f6050ec37c16.png">

- `config.storage :fog`
<img width="444" alt="Ảnh chụp Màn hình 2021-09-11 lúc 19 44 32" src="https://user-images.githubusercontent.com/18423124/132948720-fd94812e-3680-4800-ba2a-57643e4d01c1.png">

## Expected results
### when file has complicated extensions , ex: `complex.filename.tar.gz`
- basename: `complex.filename`
- extension: `tar.gz`

### when file has simple extension, ex: `simple.extension`
- basename: `simple`
- extension: `extension`

### when file has no extension, ex: `filename`
- basename: `filename`
- extension: `""`